### PR TITLE
Change location of meza secret config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN bash /opt/meza/src/scripts/getmeza.sh
 
 RUN meza setup env monolith --fqdn="INSERT_FQDN" --db_pass=1234 --enable_email=false --private_net_zone=public
 
-RUN echo "" >> /opt/meza/config/local-secret/monolith/group_vars/all.yml
-RUN echo "docker_skip_tasks: true" >> /opt/meza/config/local-secret/monolith/group_vars/all.yml
+RUN echo "" >> /opt/conf-meza/secret/monolith/group_vars/all.yml
+RUN echo "docker_skip_tasks: true" >> /opt/conf-meza/secret/monolith/group_vars/all.yml
 
 RUN meza deploy monolith

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jamesmontalvo3/meza-docker-pre-yum:latest
 MAINTAINER James Montalvo
 ENV container=docker
 
-RUN git clone https://github.com/enterprisemediawiki/meza /opt/meza --branch reorg
+RUN git clone https://github.com/enterprisemediawiki/meza /opt/meza
 # COPY . /opt/meza
 
 RUN bash /opt/meza/src/scripts/getmeza.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jamesmontalvo3/meza-docker-pre-yum:latest
 MAINTAINER James Montalvo
 ENV container=docker
 
-RUN git clone https://github.com/enterprisemediawiki/meza /opt/meza
+RUN git clone https://github.com/enterprisemediawiki/meza /opt/meza --branch reorg
 # COPY . /opt/meza
 
 RUN bash /opt/meza/src/scripts/getmeza.sh


### PR DESCRIPTION
Change location of meza secret config. Since this was not applicable to meza `master` branch initially, first had to use meza `reorg` branch. Then once merged into meza `master`, change this repo back to using meza `master`.